### PR TITLE
Take lengths of the box as input to addBox method

### DIFF
--- a/include/gepetto/viewer/windows-manager.h
+++ b/include/gepetto/viewer/windows-manager.h
@@ -150,6 +150,11 @@ namespace graphics {
 
             virtual bool addFloor(const std::string& floorName);
 
+            /// Add a box in the scene
+            /// \param boxName name of the box,
+            /// \param boxSize1, boxSize2, boxSize3 lengths of the box along
+            ///        axes x, y, z,
+            /// \param color the color of the box.
             virtual bool addBox(const std::string& boxName, const float& boxSize1, const float& boxSize2, const float& boxSize3, const Color_t& color);
 
             virtual bool addCapsule(const std::string& capsuleName, float radius, float height, const Color_t& color);

--- a/src/urdf-parser.cpp
+++ b/src/urdf-parser.cpp
@@ -313,7 +313,7 @@ namespace graphics {
 	LeafNodeBoxPtr_t boxNode = LeafNodeBox::create
 	  (oss.str (),
 	   osgVector3((float)(.5*box_shared_ptr->dim.x),
-		      (float)(.5*box_shared_ptr->dim.y), 
+		      (float)(.5*box_shared_ptr->dim.y),
 		      (float)(.5*box_shared_ptr->dim.z)));
           osgVector3 static_pos; osgQuat static_quat;
 	  if (linkFrame) {

--- a/src/windows-manager.cpp
+++ b/src/windows-manager.cpp
@@ -383,7 +383,7 @@ namespace graphics {
         RETURN_FALSE_IF_NODE_EXISTS(boxName);
 
         LeafNodeBoxPtr_t box = LeafNodeBox::create
-          (boxName, osgVector3 (boxSize1, boxSize2, boxSize3), color);
+          (boxName, osgVector3 (.5*boxSize1, .5*boxSize2, .5*boxSize3), color);
         ScopedLock lock(osgFrameMutex());
         addNode (boxName, box, true);
         return true;


### PR DESCRIPTION
  For some reason, constructor of class LeafNodeBox takes as input the half
  lengths of the box to be constructed.
  WindowsManager::addBox also takes the half lengths as input, although
    1. the method is not commented,
    2. the input parameters are called boxSize1, boxSize2, boxSize3.
  In gepetto-viewer-corba, idl method addBox therefore also takes half lengths
  as input although the comment of the method specifies lengths (of the box).

  This commit modifies method WindowsManager::addBox to make it take the lengths
  as input. It also updates urdf parser so that users loading urdf files with
  boxes will not see any difference.
  After this commit, users adding boxes through idl interface of
  gepetto-viewer-corba will have to update their scripts.