### PR TITLE
[CMake] remove duplicate header declaration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,6 @@ SET(${LIBRARY_NAME}_SOURCES
   gui/node-action.cc
   gui/osgwidget.cc
   gui/pick-handler.cc
-  gui/python-decorator.hh
   gui/selection-event.cc
   gui/selection-handler.cc
   gui/settings.cc


### PR DESCRIPTION
This header includes PythonQt.h, so we should keep only the part here:
https://github.com/Gepetto/gepetto-viewer/blob/0169d4b4da6c22fdc6354913b4a9fc1a8f768087/src/CMakeLists.txt#L88-L94

While here, I updated the submodule. This can be splitted in 2.