### PR TITLE
Give verbose error if viewer fails to be created

### DIFF
--- a/src/window-manager.cpp
+++ b/src/window-manager.cpp
@@ -131,6 +131,10 @@ namespace viewer {
       viewer_ptr_->getWindows(windows);
       manipulator_ptr = new ::osgGA::KeySwitchMatrixManipulator;
       manipulator_ptr->addMatrixManipulator('1',"trackball",new ::osgGA::TrackballManipulator);
+      if (windows.empty()){
+        throw std::runtime_error("Failed to create a window. This might be due to "
+          "incorrect GPU driver installation or hardware issue.");
+      }
       manipulator_ptr->addMatrixManipulator('2',"keyboard",new ::osgGA::KeyboardManipulator(windows.front()));
       manipulator_ptr->addMatrixManipulator('3',"tracker",new ::osgGA::NodeTrackerManipulator);
       viewer_ptr_->setCameraManipulator( manipulator_ptr);


### PR DESCRIPTION
When the windows fail to be created, due to errors such as graphics card
driver version mismatch, the GUI currently closes abruptly. We would
like to close it gracefully, with verbose message for easy debugging.