### PR TITLE
Fixed compilation following issue: "error: unknown type name 'GLDEBUGROC'

### DIFF
--- a/include/gepetto/gui/plugin-interface.hh
+++ b/include/gepetto/gui/plugin-interface.hh
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018, LAAS-CNRS
+// Copyright (c) 2015-2022, LAAS-CNRS, Heriot-Watt University
 // Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
 //
 // This file is part of gepetto-viewer.
@@ -18,7 +18,6 @@
 #define GEPETTO_GUI_PLUGININTERFACE_HH
 
 #include <QWidget>
-#include <QtGui>
 #include <gepetto/gui/dialog/dialogloadenvironment.hh>
 #include <gepetto/gui/dialog/dialogloadrobot.hh>
 #include <iostream>


### PR DESCRIPTION
I am recently moving my development to a Mac M1 laptop.
And unfortunately, the current Conda installation does not support my ARM chip.

In this setup, I installed the following packages from homebrew:
  - openscenegraph
  - qt5

then, I installed form source osgQT using 3.5.7 version (the current master branch doesn't work as noticed by @nim65s).

After doing that, I realised that this package was not compiling neither.
Below, you can see details of the compilation error.

And this PR is fixing that issue.

```bash
In file included from /Users/cm2099/Devel/gepetto-viewer/src/gui/node-action.cc:20:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/mainwindow.hh:27:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/dialog/pluginmanagerdialog.hh:26:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/plugin-interface.hh:21:
In file included from /opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/QtGui:49:
In file included from /opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/qopenglcontext.h:61:
/opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/qopenglversionfunctions.h:1096:23: error: unknown type name 'GLDEBUGPROC'
    QT_OPENGL_DECLARE(QT_OPENGL_4_3_FUNCTIONS);
                      ^
In file included from /Users/cm2099/Devel/gepetto-viewer/src/gui/node-action.cc:20:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/mainwindow.hh:27:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/dialog/pluginmanagerdialog.hh:26:
In file included from /Users/cm2099/Devel/gepetto-viewer/include/gepetto/gui/plugin-interface.hh:21:
In file included from /opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/QtGui:51:
/opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/qopenglextrafunctions.h:472:33: error: unknown type name 'GLDEBUGPROC'
    void glDebugMessageCallback(GLDEBUGPROC callback, const void *userParam);
                                ^
/opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/qopenglextrafunctions.h:758:23: error: unknown type name 'GLDEBUGPROC'
    QT_OPENGL_DECLARE(QT_OPENGL_EXTRA_FUNCTIONS)
                      ^
/opt/homebrew/opt/qt5/lib/QtGui.framework/Headers/qopenglextrafunctions.h:2213:59: error: unknown type name 'GLDEBUGPROC'
inline void QOpenGLExtraFunctions::glDebugMessageCallback(GLDEBUGPROC callback, const void * userParam)
```bash