### PR TITLE
OSX: need GLDEBUGPROC to be define before any other Qt import

### DIFF
--- a/include/gepetto/gui/action-search-bar.hh
+++ b/include/gepetto/gui/action-search-bar.hh
@@ -17,11 +17,12 @@
 #ifndef GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 #define GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 
+#include <gepetto/gui/fwd.hh>
+
 #include <QLineEdit>
 #include <QMap>
 #include <QString>
 #include <QStringListModel>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/action-search-bar.hh
+++ b/include/gepetto/gui/action-search-bar.hh
@@ -17,11 +17,12 @@
 #ifndef GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 #define GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <QLineEdit>
 #include <QMap>
 #include <QString>
 #include <QStringListModel>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/action-search-bar.hh
+++ b/include/gepetto/gui/action-search-bar.hh
@@ -17,12 +17,11 @@
 #ifndef GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 #define GEPETTO_GUI_ACTION_SEARCH_BAR_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QLineEdit>
 #include <QMap>
 #include <QString>
 #include <QStringListModel>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/bodytreewidget.hh
+++ b/include/gepetto/gui/bodytreewidget.hh
@@ -17,12 +17,13 @@
 #ifndef GEPETTO_GUI_BODYTREEWIDGET_HH
 #define GEPETTO_GUI_BODYTREEWIDGET_HH
 
+#include <gepetto/gui/fwd.hh>
+
 #include <QStandardItemModel>
 #include <QToolBox>
 #include <QTreeView>
 #include <QVector3D>
 #include <QWidget>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/bodytreewidget.hh
+++ b/include/gepetto/gui/bodytreewidget.hh
@@ -17,12 +17,13 @@
 #ifndef GEPETTO_GUI_BODYTREEWIDGET_HH
 #define GEPETTO_GUI_BODYTREEWIDGET_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <QStandardItemModel>
 #include <QToolBox>
 #include <QTreeView>
 #include <QVector3D>
 #include <QWidget>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/bodytreewidget.hh
+++ b/include/gepetto/gui/bodytreewidget.hh
@@ -17,13 +17,12 @@
 #ifndef GEPETTO_GUI_BODYTREEWIDGET_HH
 #define GEPETTO_GUI_BODYTREEWIDGET_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QStandardItemModel>
 #include <QToolBox>
 #include <QTreeView>
 #include <QVector3D>
 #include <QWidget>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/fwd.hh
+++ b/include/gepetto/gui/fwd.hh
@@ -17,8 +17,9 @@
 #ifndef GEPETTO_GUI_FWD_HH
 #define GEPETTO_GUI_FWD_HH
 
-#include <QtGlobal>
 #include <vector>
+
+#include <QtGlobal>
 #if QT_VERSION >= 0x050000
 #include <QtGui/qopengl.h>
 #ifdef __APPLE__
@@ -30,10 +31,10 @@ typedef void(APIENTRY *GLDEBUGPROC)(GLenum source, GLenum type, GLuint id,
                                     const GLvoid *userParam);
 #endif
 #endif
+#include <QtGui>
+
 #include <gepetto/viewer/fwd.h>
 #include <gepetto/viewer/macros.h>
-
-#include <QtGui>
 #include <gepetto/gui/config-dep.hh>
 
 namespace gepetto {

--- a/include/gepetto/gui/fwd.hh
+++ b/include/gepetto/gui/fwd.hh
@@ -17,9 +17,8 @@
 #ifndef GEPETTO_GUI_FWD_HH
 #define GEPETTO_GUI_FWD_HH
 
-#include <vector>
-
 #include <QtGlobal>
+#include <vector>
 #if QT_VERSION >= 0x050000
 #include <QtGui/qopengl.h>
 #ifdef __APPLE__
@@ -31,10 +30,10 @@ typedef void(APIENTRY *GLDEBUGPROC)(GLenum source, GLenum type, GLuint id,
                                     const GLvoid *userParam);
 #endif
 #endif
-#include <QtGui>
-
 #include <gepetto/viewer/fwd.h>
 #include <gepetto/viewer/macros.h>
+
+#include <QtGui>
 #include <gepetto/gui/config-dep.hh>
 
 namespace gepetto {

--- a/include/gepetto/gui/node-action.hh
+++ b/include/gepetto/gui/node-action.hh
@@ -17,8 +17,9 @@
 #ifndef GEPETTO_GUI_NODE_ACTION_HH
 #define GEPETTO_GUI_NODE_ACTION_HH
 
-#include <QAction>
 #include <gepetto/gui/fwd.hh>
+
+#include <QAction>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/node-action.hh
+++ b/include/gepetto/gui/node-action.hh
@@ -17,9 +17,8 @@
 #ifndef GEPETTO_GUI_NODE_ACTION_HH
 #define GEPETTO_GUI_NODE_ACTION_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QAction>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/node-action.hh
+++ b/include/gepetto/gui/node-action.hh
@@ -17,8 +17,9 @@
 #ifndef GEPETTO_GUI_NODE_ACTION_HH
 #define GEPETTO_GUI_NODE_ACTION_HH
 
-#include <QAction>
 #include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
+#include <QAction>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/osgwidget.hh
+++ b/include/gepetto/gui/osgwidget.hh
@@ -17,13 +17,13 @@
 #ifndef GEPETTO_GUI_OSGWIDGET_HH
 #define GEPETTO_GUI_OSGWIDGET_HH
 
+#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/config-osg.h>
 
 #include <QLabel>
 #include <QString>
 #include <QThread>
 #include <QTimer>
-#include <gepetto/gui/fwd.hh>
 #include <osg/ref_ptr>
 #include <osgQt/GraphicsWindowQt>
 #include <osgViewer/ViewerBase>

--- a/include/gepetto/gui/osgwidget.hh
+++ b/include/gepetto/gui/osgwidget.hh
@@ -17,13 +17,13 @@
 #ifndef GEPETTO_GUI_OSGWIDGET_HH
 #define GEPETTO_GUI_OSGWIDGET_HH
 
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/config-osg.h>
 
 #include <QLabel>
 #include <QString>
 #include <QThread>
 #include <QTimer>
+#include <gepetto/gui/fwd.hh>
 #include <osg/ref_ptr>
 #include <osgQt/GraphicsWindowQt>
 #include <osgViewer/ViewerBase>

--- a/include/gepetto/gui/osgwidget.hh
+++ b/include/gepetto/gui/osgwidget.hh
@@ -17,13 +17,14 @@
 #ifndef GEPETTO_GUI_OSGWIDGET_HH
 #define GEPETTO_GUI_OSGWIDGET_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <gepetto/viewer/config-osg.h>
 
 #include <QLabel>
 #include <QString>
 #include <QThread>
 #include <QTimer>
-#include <gepetto/gui/fwd.hh>
 #include <osg/ref_ptr>
 #include <osgQt/GraphicsWindowQt>
 #include <osgViewer/ViewerBase>

--- a/include/gepetto/gui/pick-handler.hh
+++ b/include/gepetto/gui/pick-handler.hh
@@ -17,10 +17,9 @@
 #ifndef GEPETTO_GUI_PICK_HANDLER_HH
 #define GEPETTO_GUI_PICK_HANDLER_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QModelIndex>
 #include <QObject>
+#include <gepetto/gui/fwd.hh>
 #include <gepetto/gui/qt-osg-keyboard.hh>
 #include <osg/ref_ptr>
 #include <osgGA/GUIEventHandler>

--- a/include/gepetto/gui/pick-handler.hh
+++ b/include/gepetto/gui/pick-handler.hh
@@ -17,9 +17,10 @@
 #ifndef GEPETTO_GUI_PICK_HANDLER_HH
 #define GEPETTO_GUI_PICK_HANDLER_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <QModelIndex>
 #include <QObject>
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/gui/qt-osg-keyboard.hh>
 #include <osg/ref_ptr>
 #include <osgGA/GUIEventHandler>

--- a/include/gepetto/gui/pick-handler.hh
+++ b/include/gepetto/gui/pick-handler.hh
@@ -17,9 +17,10 @@
 #ifndef GEPETTO_GUI_PICK_HANDLER_HH
 #define GEPETTO_GUI_PICK_HANDLER_HH
 
+#include <gepetto/gui/fwd.hh>
+
 #include <QModelIndex>
 #include <QObject>
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/gui/qt-osg-keyboard.hh>
 #include <osg/ref_ptr>
 #include <osgGA/GUIEventHandler>

--- a/include/gepetto/gui/plugin-interface.hh
+++ b/include/gepetto/gui/plugin-interface.hh
@@ -17,12 +17,13 @@
 #ifndef GEPETTO_GUI_PLUGININTERFACE_HH
 #define GEPETTO_GUI_PLUGININTERFACE_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <QOpenGLContext>
 #include <QWidget>
 #include <QtGui>
 #include <gepetto/gui/dialog/dialogloadenvironment.hh>
 #include <gepetto/gui/dialog/dialogloadrobot.hh>
-#include <gepetto/gui/fwd.hh>
 #include <iostream>
 
 namespace gepetto {

--- a/include/gepetto/gui/plugin-interface.hh
+++ b/include/gepetto/gui/plugin-interface.hh
@@ -17,6 +17,9 @@
 #ifndef GEPETTO_GUI_PLUGININTERFACE_HH
 #define GEPETTO_GUI_PLUGININTERFACE_HH
 
+#include <gepetto/gui/fwd.hh>
+
+#include <QOpenGLContext>
 #include <QWidget>
 #include <QtGui>
 #include <gepetto/gui/dialog/dialogloadenvironment.hh>

--- a/include/gepetto/gui/plugin-interface.hh
+++ b/include/gepetto/gui/plugin-interface.hh
@@ -17,13 +17,12 @@
 #ifndef GEPETTO_GUI_PLUGININTERFACE_HH
 #define GEPETTO_GUI_PLUGININTERFACE_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QOpenGLContext>
 #include <QWidget>
 #include <QtGui>
 #include <gepetto/gui/dialog/dialogloadenvironment.hh>
 #include <gepetto/gui/dialog/dialogloadrobot.hh>
+#include <gepetto/gui/fwd.hh>
 #include <iostream>
 
 namespace gepetto {

--- a/include/gepetto/gui/pythonwidget.hh
+++ b/include/gepetto/gui/pythonwidget.hh
@@ -17,8 +17,8 @@
 #ifndef GEPETTO_GUI_PYTHONWIDGET_HH
 #define GEPETTO_GUI_PYTHONWIDGET_HH
 
-#include <gepetto/gui/config-dep.hh>
 #include <gepetto/gui/fwd.hh>
+#include <gepetto/gui/config-dep.hh>
 
 #if !GEPETTO_GUI_HAS_PYTHONQT
 #error "gepetto-viewer was not compile with PythonQt dependency."

--- a/include/gepetto/gui/pythonwidget.hh
+++ b/include/gepetto/gui/pythonwidget.hh
@@ -17,8 +17,9 @@
 #ifndef GEPETTO_GUI_PYTHONWIDGET_HH
 #define GEPETTO_GUI_PYTHONWIDGET_HH
 
-#include <gepetto/gui/config-dep.hh>
 #include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
+#include <gepetto/gui/config-dep.hh>
 
 #if !GEPETTO_GUI_HAS_PYTHONQT
 #error "gepetto-viewer was not compile with PythonQt dependency."

--- a/include/gepetto/gui/pythonwidget.hh
+++ b/include/gepetto/gui/pythonwidget.hh
@@ -17,8 +17,8 @@
 #ifndef GEPETTO_GUI_PYTHONWIDGET_HH
 #define GEPETTO_GUI_PYTHONWIDGET_HH
 
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/gui/config-dep.hh>
+#include <gepetto/gui/fwd.hh>
 
 #if !GEPETTO_GUI_HAS_PYTHONQT
 #error "gepetto-viewer was not compile with PythonQt dependency."

--- a/include/gepetto/gui/safeapplication.hh
+++ b/include/gepetto/gui/safeapplication.hh
@@ -17,10 +17,11 @@
 #ifndef GEPETTO_GUI_SAFEAPPLICATION_HH
 #define GEPETTO_GUI_SAFEAPPLICATION_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <assert.h>
 
 #include <QApplication>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/safeapplication.hh
+++ b/include/gepetto/gui/safeapplication.hh
@@ -19,9 +19,8 @@
 
 #include <assert.h>
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QApplication>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/safeapplication.hh
+++ b/include/gepetto/gui/safeapplication.hh
@@ -19,8 +19,9 @@
 
 #include <assert.h>
 
-#include <QApplication>
 #include <gepetto/gui/fwd.hh>
+
+#include <QApplication>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-event.hh
+++ b/include/gepetto/gui/selection-event.hh
@@ -17,13 +17,13 @@
 #ifndef GEPETTO_GUI_SELECTION_EVENT_HH
 #define GEPETTO_GUI_SELECTION_EVENT_HH
 
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/node.h>
 
 #include <QAtomicInt>
 #include <QObject>
 #include <QString>
 #include <QVector3D>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-event.hh
+++ b/include/gepetto/gui/selection-event.hh
@@ -17,13 +17,13 @@
 #ifndef GEPETTO_GUI_SELECTION_EVENT_HH
 #define GEPETTO_GUI_SELECTION_EVENT_HH
 
+#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/node.h>
 
 #include <QAtomicInt>
 #include <QObject>
 #include <QString>
 #include <QVector3D>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-event.hh
+++ b/include/gepetto/gui/selection-event.hh
@@ -17,13 +17,14 @@
 #ifndef GEPETTO_GUI_SELECTION_EVENT_HH
 #define GEPETTO_GUI_SELECTION_EVENT_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <gepetto/viewer/node.h>
 
 #include <QAtomicInt>
 #include <QObject>
 #include <QString>
 #include <QVector3D>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-handler.hh
+++ b/include/gepetto/gui/selection-handler.hh
@@ -17,11 +17,12 @@
 #ifndef GEPETTO_GUI_SELECTION_HANDLER_H__
 #define GEPETTO_GUI_SELECTION_HANDLER_H__
 
+#include <gepetto/gui/fwd.hh>
+
 #include <QComboBox>
 #include <QKeyEvent>
 #include <QVector3D>
 #include <QWidget>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-handler.hh
+++ b/include/gepetto/gui/selection-handler.hh
@@ -17,11 +17,12 @@
 #ifndef GEPETTO_GUI_SELECTION_HANDLER_H__
 #define GEPETTO_GUI_SELECTION_HANDLER_H__
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <QComboBox>
 #include <QKeyEvent>
 #include <QVector3D>
 #include <QWidget>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/selection-handler.hh
+++ b/include/gepetto/gui/selection-handler.hh
@@ -17,12 +17,11 @@
 #ifndef GEPETTO_GUI_SELECTION_HANDLER_H__
 #define GEPETTO_GUI_SELECTION_HANDLER_H__
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QComboBox>
 #include <QKeyEvent>
 #include <QVector3D>
 #include <QWidget>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/tree-item.hh
+++ b/include/gepetto/gui/tree-item.hh
@@ -17,6 +17,9 @@
 #ifndef GEPETTO_GUI_TREEITEM_HH
 #define GEPETTO_GUI_TREEITEM_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
+
 #include <QDoubleSpinBox>
 #include <QItemDelegate>
 #include <QMenu>
@@ -24,7 +27,6 @@
 #include <QSignalMapper>
 #include <QSlider>
 #include <QStandardItem>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/tree-item.hh
+++ b/include/gepetto/gui/tree-item.hh
@@ -17,6 +17,8 @@
 #ifndef GEPETTO_GUI_TREEITEM_HH
 #define GEPETTO_GUI_TREEITEM_HH
 
+#include <gepetto/gui/fwd.hh>
+
 #include <QDoubleSpinBox>
 #include <QItemDelegate>
 #include <QMenu>
@@ -24,7 +26,6 @@
 #include <QSignalMapper>
 #include <QSlider>
 #include <QStandardItem>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/tree-item.hh
+++ b/include/gepetto/gui/tree-item.hh
@@ -17,8 +17,6 @@
 #ifndef GEPETTO_GUI_TREEITEM_HH
 #define GEPETTO_GUI_TREEITEM_HH
 
-#include <gepetto/gui/fwd.hh>
-
 #include <QDoubleSpinBox>
 #include <QItemDelegate>
 #include <QMenu>
@@ -26,6 +24,7 @@
 #include <QSignalMapper>
 #include <QSlider>
 #include <QStandardItem>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/windows-manager.hh
+++ b/include/gepetto/gui/windows-manager.hh
@@ -17,12 +17,13 @@
 #ifndef GEPETTO_GUI_WINDOWSMANAGER_HH
 #define GEPETTO_GUI_WINDOWSMANAGER_HH
 
+#include <gepetto/gui/fwd.hh>
+// This include must be include before any other Qt include for GLDEBUGPROC
 #include <gepetto/viewer/windows-manager.h>
 
 #include <QColor>
 #include <QObject>
 #include <QVector3D>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/windows-manager.hh
+++ b/include/gepetto/gui/windows-manager.hh
@@ -17,12 +17,12 @@
 #ifndef GEPETTO_GUI_WINDOWSMANAGER_HH
 #define GEPETTO_GUI_WINDOWSMANAGER_HH
 
+#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/windows-manager.h>
 
 #include <QColor>
 #include <QObject>
 #include <QVector3D>
-#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {

--- a/include/gepetto/gui/windows-manager.hh
+++ b/include/gepetto/gui/windows-manager.hh
@@ -17,12 +17,12 @@
 #ifndef GEPETTO_GUI_WINDOWSMANAGER_HH
 #define GEPETTO_GUI_WINDOWSMANAGER_HH
 
-#include <gepetto/gui/fwd.hh>
 #include <gepetto/viewer/windows-manager.h>
 
 #include <QColor>
 #include <QObject>
 #include <QVector3D>
+#include <gepetto/gui/fwd.hh>
 
 namespace gepetto {
 namespace gui {


### PR DESCRIPTION
It was undone with the "format" commit, but for OSX, we need to define  GLDEBUGPROC before any other Qt import. This is done `gepetto/gui/fwd.hh`, so the include of this file must be the first in every gui folder files that import it.