### PR TITLE
WindowsManager::setTexture() tests for more node types before failing

### DIFF
--- a/src/windows-manager.cpp
+++ b/src/windows-manager.cpp
@@ -591,16 +591,35 @@ bool WindowsManager::addSquareFace(
 
 bool WindowsManager::setTexture(const std::string& nodeName,
                                 const std::string& filename) {
-  FIND_NODE_OF_TYPE_OR_THROW(LeafNodeFace, faceNode, nodeName);
-
-  if (faceNode->nbVertices() != 4) {
-    std::ostringstream oss;
-    oss << "Face should have 4 vertices to apply texture. " << nodeName
-        << " has " << faceNode->nbVertices() << ".";
-    throw std::runtime_error(oss.str());
+  NodePtr_t node = getNode(nodeName, true);
+  
+  LeafNodeFacePtr_t faceNode = dynamic_pointer_cast<LeafNodeFace>(node);
+  if (faceNode) {
+      if (faceNode->nbVertices() != 4) {
+          std::ostringstream oss;
+          oss << "Face should have 4 vertices to apply texture. " << nodeName
+              << " has " << faceNode->nbVertices() << ".";
+          throw std::runtime_error(oss.str());
+      }
+      faceNode->setTexture(filename);
+      return true;
   }
-  faceNode->setTexture(filename);
-  return true;
+  
+  NodeDrawablePtr_t nd = dynamic_pointer_cast<NodeDrawable>(node);
+  if (nd) {
+      nd->setTexture(filename);
+      return true;
+  }
+  
+  LeafNodeColladaPtr_t lc = dynamic_pointer_cast<LeafNodeCollada>(node);
+  if (lc) {
+      lc->setTexture(filename);
+      return true;
+  }
+  
+  std::ostringstream oss;
+  oss << "Node \"" << nodeName << "\" is not of type LeafNodeFace, NodeDrawable, or LeafNodeCollada";
+  throw std::invalid_argument(oss.str());
 }
 
 bool WindowsManager::addXYZaxis(const std::string& nodeName,


### PR DESCRIPTION
When doing benchmarks using hpp-python, we had issues displaying textures because we didn't use the urdf parser. This commit make the WindowsManager::setTexture() mimick the urdf parsing function behaviour.